### PR TITLE
Deal with ToC selectors that contain `.`, etc.,

### DIFF
--- a/source/javascripts/app/_toc.js
+++ b/source/javascripts/app/_toc.js
@@ -38,8 +38,7 @@
       $toc.find(tocLinkSelector).each(function() {
         var targetId = $(this).attr('href');
         if (targetId[0] === "#") {
-          var selector = targetId.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" );
-          headerHeights[targetId] = $(selector).offset().top;
+          headerHeights[targetId] = $("#" + $.escapeSelector(targetId.substring(1)).offset().top;
         }
       });
     };

--- a/source/javascripts/app/_toc.js
+++ b/source/javascripts/app/_toc.js
@@ -38,7 +38,8 @@
       $toc.find(tocLinkSelector).each(function() {
         var targetId = $(this).attr('href');
         if (targetId[0] === "#") {
-          headerHeights[targetId] = $(targetId).offset().top;
+          var selector = targetId.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" );
+          headerHeights[targetId] = $(selector).offset().top;
         }
       });
     };

--- a/source/javascripts/app/_toc.js
+++ b/source/javascripts/app/_toc.js
@@ -38,7 +38,7 @@
       $toc.find(tocLinkSelector).each(function() {
         var targetId = $(this).attr('href');
         if (targetId[0] === "#") {
-          headerHeights[targetId] = $("#" + $.escapeSelector(targetId.substring(1)).offset().top;
+          headerHeights[targetId] = $("#" + $.escapeSelector(targetId.substring(1))).offset().top;
         }
       });
     };


### PR DESCRIPTION
Tools like go-swag can produce schemas with IDs that contain `.` and other characters that are used in CSS notation. Those IDs can't be used properly in a jQuery selector unless the special characters are escaped. Trying to use Slate with Markdown files that contain ToC IDs with `.`, etc., results in Javascript exception and causes the Language tabs to stop working.

```
jQuery.Deferred exception: Cannot read property 'top' of undefined TypeError: Cannot read property 'top' of undefined
    at HTMLAnchorElement.<anonymous> (http://localhost:4567/javascripts/all.js:10473:57)
    at Function.each (http://localhost:4567/javascripts/all.js:533:19)
    at jQuery.fn.init.each (http://localhost:4567/javascripts/all.js:328:17)
    at recacheHeights (http://localhost:4567/javascripts/all.js:10470:34)
    at makeToc (http://localhost:4567/javascripts/all.js:10525:7)
    at loadToc (http://localhost:4567/javascripts/all.js:10547:5)
    at HTMLDocument.<anonymous> (http://localhost:4567/javascripts/all.js:10725:3)
    at mightThrow (http://localhost:4567/javascripts/all.js:3754:29)
    at process (http://localhost:4567/javascripts/all.js:3822:12) undefined
jQuery.Deferred.exceptionHook @ all.js:4031
process @ all.js:3826
setTimeout (async)
(anonymous) @ all.js:3860
fire @ all.js:3488
fireWith @ all.js:3618
fire @ all.js:3626
fire @ all.js:3488
fireWith @ all.js:3618
ready @ all.js:4091
completed @ all.js:4101

Uncaught TypeError: Cannot read property 'top' of undefined
    at HTMLAnchorElement.<anonymous> (all.js:10473)
    at Function.each (all.js:533)
    at jQuery.fn.init.each (all.js:328)
    at recacheHeights (all.js:10470)
    at makeToc (all.js:10525)
    at loadToc (all.js:10547)
    at HTMLDocument.<anonymous> (all.js:10725)
    at mightThrow (all.js:3754)
    at process (all.js:3822)
```