### PR TITLE
Added Travis CI build and deploy to Github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can now see the docs at http://localhost:4567. Whoa! That was fast!
 
 Now that Slate is all set up on your machine, you'll probably want to learn more about [editing Slate markdown](https://github.com/lord/slate/wiki/Markdown-Syntax), or [how to publish your docs](https://github.com/lord/slate/wiki/Deploying-Slate). 
 
-You can also use CI to build your documentation for you withouth any fork of direct inclusion if this repository. For a working example see `ci-build/` folder.
+You can also use CI to build your documentation for you without any fork or direct inclusion of this repository. For a working example see `ci-build/` folder.
 
 If you'd prefer to use Docker, instructions are available [in the wiki](https://github.com/lord/slate/wiki/Docker).
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ vagrant up
 
 You can now see the docs at http://localhost:4567. Whoa! That was fast!
 
-Now that Slate is all set up on your machine, you'll probably want to learn more about [editing Slate markdown](https://github.com/lord/slate/wiki/Markdown-Syntax), or [how to publish your docs](https://github.com/lord/slate/wiki/Deploying-Slate).
+Now that Slate is all set up on your machine, you'll probably want to learn more about [editing Slate markdown](https://github.com/lord/slate/wiki/Markdown-Syntax), or [how to publish your docs](https://github.com/lord/slate/wiki/Deploying-Slate). 
+
+You can also use CI to build your documentation for you withouth any fork of direct inclusion if this repository. For a working example see `ci-build/` folder.
 
 If you'd prefer to use Docker, instructions are available [in the wiki](https://github.com/lord/slate/wiki/Docker).
 

--- a/ci-build/.travis.yml
+++ b/ci-build/.travis.yml
@@ -1,0 +1,24 @@
+language: ruby
+
+rvm:
+  - 2.4.0
+
+cache: bundler
+
+before_install:
+  - git clone https://github.com/lord/slate.git
+  - mv -f docs/* slate/source/
+  - cd slate
+
+script:
+  - bundle exec middleman build
+
+deploy:
+  provider: pages
+  local_dir: slate/build/
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  keep_history: true
+  target_branch: gh-pages
+  on:
+    branch: master

--- a/ci-build/README.md
+++ b/ci-build/README.md
@@ -1,10 +1,10 @@
 # Deploy to pages with CI
 
-With CI build you can easly create and build you repository documentation without cloning/forking/including slate repository.
+With CI build you can easily create and build your repository documentation without cloning/forking/including slate repository.
 
 ## Getting started (TRAVIS CI and GITHUB)
 
-To use this deployment you will need an account on [Travis CI](https://travis-ci.org/) (100% free for open source projects)
+To use this deployment method you will need an account on [Travis CI](https://travis-ci.org/) (100% free for open source projects)
 
 1. On your `master` branch create a folder named `docs`
 
@@ -14,7 +14,7 @@ To use this deployment you will need an account on [Travis CI](https://travis-ci
 
 4. Add your repository to Travis CI - [Tutorial](https://docs.travis-ci.com/user/tutorial/)
 
-5. Generate and set you GITHUB_TOKEN - [Create a token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) - [Set Env var](https://docs.travis-ci.com/user/environment-variables/)
+5. Generate and set your GITHUB_TOKEN - [Create a token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) - [Set Env var](https://docs.travis-ci.com/user/environment-variables/)
 
 6. Now you are ready to create your pages in the `docs/` folder as you would do in a standard slate fork
 
@@ -22,7 +22,7 @@ To use this deployment you will need an account on [Travis CI](https://travis-ci
 
 
 ### Notes
- - This solution is designed to work only with Github and Travis Ci, no other ci platform is supported. You can always use the `.travis.yml` as the base idea for your own platform
+ - This solution is designed to work only with Github and Travis CI, no other CI platform is supported. You can always use the `.travis.yml` as the base idea for your own platform
  - The push on `gh-pages` branch deletes everything on that branch and leaves only the files built from slate
 
 

--- a/ci-build/README.md
+++ b/ci-build/README.md
@@ -1,0 +1,41 @@
+# Deploy to pages with CI
+
+With CI build you can easly create and build you repository documentation without cloning/forking/including slate repository.
+
+## Getting started (TRAVIS CI and GITHUB)
+
+To use this deployment you will need an account on [Travis CI](https://travis-ci.org/) (100% free for open source projects)
+
+1. On your `master` branch create a folder named `docs`
+
+2. Create a branch called `gh-pages` (if not present)
+
+3. If you don't have CI in your project just copy `.travis.yml` file in your repository root. If you already have CI in your project, you will have to adjust your `.travis.yml`
+
+4. Add your repository to Travis CI - [Tutorial](https://docs.travis-ci.com/user/tutorial/)
+
+5. Generate and set you GITHUB_TOKEN - [Create a token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) - [Set Env var](https://docs.travis-ci.com/user/environment-variables/)
+
+6. Now you are ready to create your pages in the `docs/` folder as you would do in a standard slate fork
+
+7. Push changes and see them live when the CI build is finished! (don't forget to enable pages for your project)
+
+
+### Notes
+ - This solution is designed to work only with Github and Travis Ci, no other ci platform is supported. You can always use the `.travis.yml` as the base idea for your own platform
+ - The push on `gh-pages` branch deletes everything on that branch and leaves only the files built from slate
+
+
+## Example Folder Structure
+
+Master struture
+
+```
+> a_dir/
+> docs/
+    - index.html.md 
+> .travis.yml
+> README.MD
+```
+
+Everything in `docs/` will be used to override the standard `source/` files.


### PR DESCRIPTION
Added CI integration to directly generate and push builded pages to `gh-pages` branch without forking the repository.

This change allows the user to keep just the doc files in the repository and generate the doc site without manually running a deploy script.