### PR TITLE
Fully parse arguments first in deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -216,9 +216,9 @@ sanitize() {
 
 parse_args "$@"
 
-if [[ $1 = --source-only ]]; then
+if [[ ${source_only} ]]; then
   run_build
-elif [[ $1 = --push-only ]]; then
+elif [[ ${push_only} ]]; then
   main "$@"
 else
   run_build

--- a/deploy.sh
+++ b/deploy.sh
@@ -36,7 +36,7 @@ parse_args() {
   while : ; do
     if [[ $1 = "-h" || $1 = "--help" ]]; then
       echo "$help_message"
-      return 0
+      exit 0
     elif [[ $1 = "-v" || $1 = "--verbose" ]]; then
       verbose=true
       shift
@@ -49,10 +49,21 @@ parse_args() {
     elif [[ $1 = "-n" || $1 = "--no-hash" ]]; then
       GIT_DEPLOY_APPEND_HASH=false
       shift
+    elif [[ $1 = "--source-only" ]]; then
+      source_only=true
+      shift
+    elif [[ $1 = "--push-only" ]]; then
+      push_only=true
+      shift
     else
       break
     fi
   done
+
+  if [ ${source_only} ] && [ ${push_only} ]; then
+    >&2 echo "You can only specify source_only or push_only"
+    exit 1
+  fi
 
   # Set internal option vars from the environment and arg flags. All internal
   # vars should be declared here, with sane defaults if applicable.
@@ -73,8 +84,6 @@ parse_args() {
 }
 
 main() {
-  parse_args "$@"
-
   enable_expanded_output
 
   if ! git diff --exit-code --quiet --cached; then
@@ -204,6 +213,8 @@ filter() {
 sanitize() {
   "$@" 2> >(filter 1>&2) | filter
 }
+
+parse_args "$@"
 
 if [[ $1 = --source-only ]]; then
   run_build

--- a/deploy.sh
+++ b/deploy.sh
@@ -61,7 +61,7 @@ parse_args() {
   done
 
   if [ ${source_only} ] && [ ${push_only} ]; then
-    >&2 echo "You can only specify source_only or push_only"
+    >&2 echo "You can only specify one of --source-only or --push-only"
     exit 1
   fi
 


### PR DESCRIPTION
`./deploy.sh` currently does a check for if the first argument is either `--push-only` or `--source-only` and then if using `--push-only` or with either, will it parse the rest of the args. This means doing `./deploy.sh --help` will build the sources first before printing the help message, and that the `--*-only` flags must be the first thing`.

This refactors it to do argument parsing first and foremost, which accomplishes the following
* Using `--help` will immediately print the help message and exit
* `--source-only` and `--push-only` can happen in any order with the other flags
* Trying to use both `--source-only` and `--push-only` will print an error message and crash out

Closes #824 