### PR TITLE
Slate 2.4 Vagrantfile issue with updated autoprefixer

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/bionic64"
   config.vm.network :forwarded_port, guest: 4567, host: 4567
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "2048"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
       sudo apt-get install -yq ruby ruby-dev
       sudo apt-get install -yq pkg-config build-essential nodejs git libxml2-dev libxslt-dev
       sudo apt-get autoremove -yq
-      gem2.4 install --no-ri --no-rdoc bundler
+      gem install --no-ri --no-rdoc bundler
     SHELL
 
   # add the local user git config to the vm

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,9 +8,8 @@ Vagrant.configure(2) do |config|
   config.vm.provision "bootstrap",
     type: "shell",
     inline: <<-SHELL
-      sudo apt-add-repository ppa:brightbox/ruby-ng
       sudo apt-get update
-      sudo apt-get install -yq ruby2.4 ruby2.4-dev
+      sudo apt-get install -yq ruby ruby-dev
       sudo apt-get install -yq pkg-config build-essential nodejs git libxml2-dev libxslt-dev
       sudo apt-get autoremove -yq
       gem2.4 install --no-ri --no-rdoc bundler


### PR DESCRIPTION
The Vagrantfile file that ships with Slate 2.4.0 causes an Internal Server Error

After "vagrant up", visiting http://localhost:4567/ gives the following error:

Internal Server Error
Autoprefixer doesnâ€™t support Node v0.10.25. Update it.

It seems Slate 2.4.0 updates the autoprefixer-rails version in Gemfile.lock.
The doc page for autoprefixer says it requires Node v6 or later - and apparently Node v0.10.25 is ancient.

The Vagrantfile currently calls for Ubuntu Trusty (14.04) which ships with Node v0.10.25


Ubuntu Xenial (16.04) fails with
Autoprefixer doesnâ€™t support Node v4.2.6. Update it.

Ubuntu Bionic (18.04) works (slate renders again)
which makes sense as Bionic (18.40) ships with Node v8.10.0

This pull request simply updates to a newer Ubuntu LTS distribution in Vagrantfile. Since Trusty is end of standard support, it made sense to me to look for a newer Ubuntu version. I don't work with Ruby, Node or Ubuntu or Vagrant on a regular basis so there may be more elegant approaches to fixing this issue. 

Thanks you for looking at this pull request,
 
Brad
