### PR TITLE
Test slate against ruby 2.5+ on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
-sudo: false
-
 language: ruby
-
 rvm:
-  - 2.3.3
-  - 2.4.0
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+
+cache: bundler
 
 before_install:
   - gem update --system
   - gem install bundler
 
-cache: bundler
 script: bundle exec middleman build


### PR DESCRIPTION
Updates the Travis targets to include Ruby 2.5 and Ruby 2.6 to help ensure slate is not going to break on current/future Ruby.