### PR TITLE
ensure updated nodejs is installed by usig 10x repo

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,9 @@ Vagrant.configure(2) do |config|
   config.vm.provision "bootstrap",
     type: "shell",
     inline: <<-SHELL
+      # add nodejs v10 repository
+      curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+
       sudo apt-get update
       sudo apt-get install -yq ruby ruby-dev
       sudo apt-get install -yq pkg-config build-essential nodejs git libxml2-dev libxslt-dev

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,8 +8,8 @@ Vagrant.configure(2) do |config|
   config.vm.provision "bootstrap",
     type: "shell",
     inline: <<-SHELL
-      # add nodejs v10 repository
-      curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+      # add nodejs v12 repository
+      curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 
       sudo apt-get update
       sudo apt-get install -yq ruby ruby-dev


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

vagrant up completed but the local server was returning a internal server error saying some dependency did not support the old version of node that was installed in vagrant by default, I simply added a nodejs10x repo to install from, this fixed the issue.
