### PR TITLE
fix bc style breaks from rouge 3.x

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -23,6 +23,7 @@ set :fonts_dir, 'fonts'
 # Activate the syntax highlighter
 activate :syntax
 ready do
+  require './lib/monokai_sublime_slate.rb'
   require './lib/multilang.rb'
 end
 

--- a/lib/monokai_sublime_slate.rb
+++ b/lib/monokai_sublime_slate.rb
@@ -67,8 +67,7 @@ module Rouge
               Literal::String::Interpol,
               Literal::String::Other,
               Literal::String::Single,
-              Literal::String,
-              Name::Label,                      :fg => :soft_yellow
+              Literal::String,                  :fg => :soft_yellow
         style Name::Attribute,
               Name::Class,
               Name::Decorator,
@@ -84,6 +83,7 @@ module Rouge
               Text::Whitespace,
               Text,
               Name,                             :fg => :white
+        style Name::Label,                      :fg => :bright_pink
         style Operator::Word,
               Name::Tag,
               Keyword,

--- a/lib/monokai_sublime_slate.rb
+++ b/lib/monokai_sublime_slate.rb
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+# this is based on https://github.com/rouge-ruby/rouge/blob/master/lib/rouge/themes/monokai_sublime.rb
+# but without the added background, and changed styling for JSON keys to be soft_yellow instead of white
+
+module Rouge
+    module Themes
+      class MonokaiSublimeSlate < CSSTheme
+        name 'monokai.sublime.slate'
+
+        palette :black          => '#000000'
+        palette :bright_green   => '#a6e22e'
+        palette :bright_pink    => '#f92672'
+        palette :carmine        => '#960050'
+        palette :dark           => '#49483e'
+        palette :dark_grey      => '#888888'
+        palette :dark_red       => '#aa0000'
+        palette :dimgrey        => '#75715e'
+        palette :emperor        => '#555555'
+        palette :grey           => '#999999'
+        palette :light_grey     => '#aaaaaa'
+        palette :light_violet   => '#ae81ff'
+        palette :soft_cyan      => '#66d9ef'
+        palette :soft_yellow    => '#e6db74'
+        palette :very_dark      => '#1e0010'
+        palette :whitish        => '#f8f8f2'
+        palette :orange         => '#f6aa11'
+        palette :white          => '#ffffff'
+
+        style Generic::Heading,                 :fg => :grey
+        style Literal::String::Regex,           :fg => :orange
+        style Generic::Output,                  :fg => :dark_grey
+        style Generic::Prompt,                  :fg => :emperor
+        style Generic::Strong,                  :bold => false
+        style Generic::Subheading,              :fg => :light_grey
+        style Name::Builtin,                    :fg => :orange
+        style Comment::Multiline,
+              Comment::Preproc,
+              Comment::Single,
+              Comment::Special,
+              Comment,                          :fg => :dimgrey
+        style Error,
+              Generic::Error,
+              Generic::Traceback,               :fg => :carmine
+        style Generic::Deleted,
+              Generic::Inserted,
+              Generic::Emph,                    :fg => :dark
+        style Keyword::Constant,
+              Keyword::Declaration,
+              Keyword::Reserved,
+              Name::Constant,
+              Keyword::Type,                    :fg => :soft_cyan
+        style Literal::Number::Float,
+              Literal::Number::Hex,
+              Literal::Number::Integer::Long,
+              Literal::Number::Integer,
+              Literal::Number::Oct,
+              Literal::Number,
+              Literal::String::Char,
+              Literal::String::Escape,
+              Literal::String::Symbol,          :fg => :light_violet
+        style Literal::String::Doc,
+              Literal::String::Double,
+              Literal::String::Backtick,
+              Literal::String::Heredoc,
+              Literal::String::Interpol,
+              Literal::String::Other,
+              Literal::String::Single,
+              Literal::String,
+              Name::Label,                      :fg => :soft_yellow
+        style Name::Attribute,
+              Name::Class,
+              Name::Decorator,
+              Name::Exception,
+              Name::Function,                   :fg => :bright_green
+        style Name::Variable::Class,
+              Name::Namespace,
+              Name::Entity,
+              Name::Builtin::Pseudo,
+              Name::Variable::Global,
+              Name::Variable::Instance,
+              Name::Variable,
+              Text::Whitespace,
+              Text,
+              Name,                             :fg => :white
+        style Operator::Word,
+              Name::Tag,
+              Keyword,
+              Keyword::Namespace,
+              Keyword::Pseudo,
+              Operator,                         :fg => :bright_pink
+      end
+    end
+  end

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -32,7 +32,7 @@ under the License.
     <title><%= current_page.data.title || "API Documentation" %></title>
 
     <style>
-      <%= Rouge::Themes::MonokaiSublime.render(:scope => '.highlight') %>
+      <%= Rouge::Themes::MonokaiSublimeSlate.render(:scope => '.highlight') %>
     </style>
     <%= stylesheet_link_tag :screen, media: :screen %>
     <%= stylesheet_link_tag :print, media: :print %>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -511,6 +511,10 @@ html, body {
 // This is all the stuff that appears in the right half of the page
 
 .content {
+  &>div.highlight {
+    clear:none;
+  }
+
   pre, blockquote {
     background-color: $code-bg;
     color: #fff;


### PR DESCRIPTION
The newest version of Rouge (somewhere in the 3.x release line) did the following changes:
1. Gave code elements a background color for Monokai Sublime theme
1. Makes JSON keys be treated as `Name::Label` instead of `Literal::String` (and so can be styled different color from the values)
1. Wraps an additional `<div class='highlight'>` around the `<pre class='highlight'>`

This PR fixes these to be inline with how Slate was doing things with older versions of Rouge (while still retaining all of the fancy new supported languages and improved parsers).

Fixes #1225 

screenshot of differences:
master:
![Screenshot 2020-05-11 12 49 13](https://user-images.githubusercontent.com/1845314/81588001-84d86700-93c0-11ea-8dc6-2ad00a836146.png)

after pr:
![Screenshot 2020-05-11 12 48 19](https://user-images.githubusercontent.com/1845314/81588014-89048480-93c0-11ea-9ec0-fee444c202ee.png)
