### PR TITLE
update screenshot in README with new rouge styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/lord/img/master/logo-slate.png" alt="Slate: API Documentation Generator" width="226">
+  <img src="https://raw.githubusercontent.com/slatedocs/img/master/logo-slate.png" alt="Slate: API Documentation Generator" width="226">
   <br>
   <a href="https://travis-ci.com/slatedocs/slate"><img src="https://travis-ci.com/slatedocs/slate.svg?branch=master" alt="Build Status"></a>
 </p>
 
 <p align="center">Slate helps you create beautiful, intelligent, responsive API documentation.</p>
 
-<p align="center"><img src="https://raw.githubusercontent.com/lord/img/master/screenshot-slate.png" width=700 alt="Screenshot of Example Documentation created with Slate"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/slatedocs/img/master/screenshot-slate.png" width=700 alt="Screenshot of Example Documentation created with Slate"></p>
 
 <p align="center"><em>The example above was created with Slate. Check it out at <a href="https://slatedocs.github.io/slate">slatedocs.github.io/slate</a>.</em></p>
 


### PR DESCRIPTION
This updates the screenshot in the README with the new rouge styling. I created a new repo, https://github.com/slatedocs/img, to hold the slate specific stuff from https://github.com/lord/img so that it's easier for slatedocs collaborators to edit them (and not work through sending a PR to the lord repo). The downside is that for this next release, READMEs will be cluttered up with old images, upside is that future versions of slate will be easy to update the screenshot or logo of.

If so desired, I can just send a PR to https://github.com/lord/img or just inline the two images into
the repo itself. Thoughts @lord, @MikeRalphson?