### PR TITLE
disable asset hash for woff and woff2 files out of the box

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -41,13 +41,16 @@ set :relative_links, true
 
 # Build Configuration
 configure :build do
-  activate :asset_hash
+  # We do want to hash woff and woff2 as there's a bug where woff2 will use
+  # woff asset hash which breaks things. Trying to use a combination of ignore and
+  # rewrite_ignore does not work as it conflicts weirdly with relative_assets. Disabling
+  # the .woff2 extension only does not work as .woff will still activate it so have to
+  # have both. See https://github.com/slatedocs/slate/issues/1171 for more details.
+  activate :asset_hash, :exts => app.config[:asset_extensions] - %w[.woff .woff2]
   # If you're having trouble with Middleman hanging, commenting
   # out the following two lines has been known to help
   activate :minify_css
   activate :minify_javascript
-  # activate :relative_assets
-  # activate :asset_hash
   # activate :gzip
 end
 


### PR DESCRIPTION
Closes #1171. 

Disables woff and woff2 support in asset hash out of the box. For whatever reason, middleman has an issue where it will write the asset hash for the woff file onto the woff2 when it's being rewritten in the css file. Attempting to use some combination of `ignore` and `ignore_rewrites` did not prove possible, and just ignoring `woff2` does not work as middleman will happily do it anyway for `woff`, so have to disable them both. It's dumb, and I hate how much time I've wasted trying to figure out a way to configure middleman to try and get it to work properly.