### PR TITLE
switch to using debian for docker base for bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
-FROM ruby:2.5-alpine
-
-RUN apk --no-cache add \
-        g++ \
-        gcc \
-        libc-dev \
-        make \
-        nodejs \
-    && gem install bundler
+FROM ruby:2.6-slim
 
 WORKDIR /srv/slate
 
+VOLUME /srv/slate/source
+EXPOSE 4567
+
 COPY . /srv/slate
 
-RUN bundle install
-
-VOLUME /srv/slate/source
-
-EXPOSE 4567
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        nodejs \
+    && gem install bundler \
+    && bundle install \
+    && apt-get remove -y build-essential \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 CMD ["bundle", "exec", "middleman", "server", "--watcher-force-polling"]


### PR DESCRIPTION
Fixes #1229 in that `./deploy.sh` requires the bash runtime for a handful of lines. I am not readily sure how to convert the lines to bash from sh, and so would rather just then use bash as the base instead. It does clock in at like 30mb smaller as well as I'm a bit better at cleaning Debian based images than alpine.