### PR TITLE
Change instructions to use templates instead of forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Features
 
 * **RTL Support** Full right-to-left layout for RTL languages such as Arabic, Persian (Farsi), Hebrew etc.
 
-Getting started with Slate is super easy! Simply fork this repository and follow the instructions below. Or, if you'd like to check out what Slate is capable of, take a look at the [sample docs](https://slatedocs.github.io/slate/).
+Getting started with Slate is super easy! Simply press the green "use this template" button above and follow the instructions below. Or, if you'd like to check out what Slate is capable of, take a look at the [sample docs](https://slatedocs.github.io/slate/).
 
 Getting Started with Slate
 ------------------------------
@@ -44,10 +44,11 @@ You're going to need:
 
 ### Getting Set Up
 
-1. Fork this repository on GitHub.
-2. Clone *your forked repository* (not our original one) to your hard drive with `git clone https://github.com/YOURUSERNAME/slate.git`
-3. `cd slate`
-4. Initialize and start Slate. You can either do this locally, or with Vagrant:
+1. Press the green "use this template" button at the top of this page.
+2. Follow the instructions to create a new copy of the Slate repository.
+3. Clone your repository (not our original one) to your hard drive with `git clone https://github.com/YOURUSERNAME/slate.git`
+4. `cd slate`
+5. Initialize and start Slate. You can either do this locally, or with Vagrant:
 
 ```shell
 # either run this to run locally


### PR DESCRIPTION
If people use templates instead of forks, their pull requests don't accidentally get sent to us 😄 

On the downside, it seems like template usage doesn't make the 'fork' count increment, but maybe we already have enough forks?