### PR TITLE
v2.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ __Note__: 2.5.0 was "pulled" due to a breaking bug discovered after release. It 
 * Disable asset hashing for woff and woff2 elements due to middleman bug breaking woff2 asset hashing in general
 * Move Dockerfile to Debian from Alpine
 * Converted repo to a [GitHub template](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-template-repository)
+* Update sassc to 2.3.0 in Gemfile.lock
 
 ## Version 2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## Version 2.5.1
+## Version 2.6.0
 
 *May 18, 2020*
 
-__Note__: 2.5.0 was "pulled" due to a breaking bug discovered after release. It is recommended to skip it to 2.5.1
+__Note__: 2.5.0 was "pulled" due to a breaking bug discovered after release. It is recommended to skip it, and move straight to 2.6.0.
 
 * Fix large whitespace gap in middle column for sections with codeblocks
 * Fix highlighted code elements having a different background than rest of code block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ __Note__: 2.5.0 was "pulled" due to a breaking bug discovered after release. It 
 * Change JSON keys to have a different font color than their values
 * Disable asset hashing for woff and woff2 elements due to middleman bug breaking woff2 asset hashing in general
 * Move Dockerfile to Debian from Alpine
+* Converted repo to a [GitHub template](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-template-repository)
 
 ## Version 2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Version 2.5.1
+
+*May 18, 2020*
+
+__Note__: 2.5.0 was "pulled" due to a breaking bug discovered after release. It is recommended to skip it to 2.5.1
+
+* Fix large whitespace gap in middle column for sections with codeblocks
+* Fix highlighted code elements having a different background than rest of code block
+* Change JSON keys to have a different font color than their values
+* Disable asset hashing for woff and woff2 elements due to middleman bug breaking woff2 asset hashing in general
+* Move Dockerfile to Debian from Alpine
+
 ## Version 2.5.0
 
 *May 8, 2020*


### PR DESCRIPTION
Fixes the breaks in 2.5.0 and includes an additional couple of fixes and features.

A full length screenshot of things to make sure I've not messed things up this time:
![localhost_4567__shell](https://user-images.githubusercontent.com/1845314/82174286-2cacd380-989e-11ea-9d82-a738764cce18.png)
