### PR TITLE
v2.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Version 2.6.1
+
+*May 28, 2020*
+
+* __[security]__ update child dependency activesupport in Gemfile.lock to 5.4.2.3
+* Update Middleman in Gemfile.lock to 4.3.7
+* Replace Travis-CI with GitHub actions for continuous integration
+* Replace Spectrum with GitHub discussions
+
 ## Version 2.6.0
 
 *May 18, 2020*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 2.6.1
 
-*May 28, 2020*
+*May 30, 2020*
 
 * __[security]__ update child dependency activesupport in Gemfile.lock to 5.4.2.3
 * Update Middleman in Gemfile.lock to 4.3.7


### PR DESCRIPTION
The primary (only) focus of this release is just updating middleman in the Gemfile.lock to no longer use a version of ActiveSupport that has a publish security advisory (that does not affect Slate).