### PR TITLE
Fix link to wiki in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Getting Started with Slate
 ------------------------------
 
 To get started with Slate, please check out the [Getting Started](https://github.com/slatedocs/slate/wiki#getting-started)
-section in our [wiki](https://github.com/slatedocs/wiki).
+section in our [wiki](https://github.com/slatedocs/slate/wiki).
 
 We support running Slate in three different ways:
 * [Natively](https://github.com/slatedocs/slate/wiki/Using-Slate-Natively)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Getting Started with Slate
 ------------------------------
 
 To get started with Slate, please check out the [Getting Started](https://github.com/slatedocs/slate/wiki#getting-started)
-section in our [wiki](https://github.com/slate/wiki).
+section in our [wiki](https://github.com/slatedocs/wiki).
 
 We support running Slate in three different ways:
 * [Natively](https://github.com/slatedocs/slate/wiki/Using-Slate-Natively)


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->