### PR TITLE
add copy to clipboard icon to code boxes

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -15,6 +15,8 @@ includes:
   - errors
 
 search: true
+
+code_clipboard: true
 ---
 
 # Introduction

--- a/source/javascripts/all_nosearch.js
+++ b/source/javascripts/all_nosearch.js
@@ -1,4 +1,5 @@
 //= require ./lib/_energize
+//= require ./app/_copy
 //= require ./app/_toc
 //= require ./app/_lang
 

--- a/source/javascripts/app/_copy.js
+++ b/source/javascripts/app/_copy.js
@@ -1,0 +1,15 @@
+function copyToClipboard(container) {
+  const el = document.createElement('textarea');
+  el.value = container.textContent;
+  document.body.appendChild(el);
+  el.select();
+  document.execCommand('copy');
+  document.body.removeChild(el);
+}
+
+function setupCodeCopy() {
+  $('pre.highlight').prepend('<div class="copy-clipboard"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Copy to Clipboard</title><path d="M18 6v-6h-18v18h6v6h18v-18h-6zm-12 10h-4v-14h14v4h-10v10zm16 6h-14v-14h14v14z"></path></svg></div>');
+  $('.copy-clipboard').on('click', function() {
+    copyToClipboard(this.parentNode.children[1]);
+  });
+}

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -41,6 +41,12 @@ under the License.
     <% else %>
       <%= javascript_include_tag  "all_nosearch" %>
     <% end %>
+
+    <% if current_page.data.code_clipboard %>
+    <script>
+      $(function() { setupCodeCopy(); });
+    </script>
+    <% end %>
   </head>
 
   <body class="<%= page_classes %>" data-languages="<%=h language_tabs.map{ |lang| lang.is_a?(Hash) ? lang.keys.first : lang }.to_json %>">

--- a/source/stylesheets/print.css.scss
+++ b/source/stylesheets/print.css.scss
@@ -145,3 +145,9 @@ body {
     @extend %icon-ok-sign;
   }
 }
+
+.copy-clipboard {
+  @media print {
+    display: none
+  }
+}

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -617,3 +617,16 @@ html, body {
 .highlight, .highlight .w {
   background-color: $code-bg;
 }
+
+.copy-clipboard {
+  float: right;
+  fill: #9DAAB6;
+  cursor: pointer;
+  opacity: 0.4;
+  height: 18px;
+  width: 18px;
+}
+
+.copy-clipboard:hover {
+  opacity: 0.8;
+}


### PR DESCRIPTION
Closes #1220

Adds a clipboard icon to the upper right corner of the code source boxes that when clicked, will copy the contents of the textarea to your clipboard. Styling / functionality of it is relatively simplistic (the tooltip is the builtin SVG title, no clear indication that clicking it triggers a "copy"), but at the moment, not sure that's a flaw. The icon will also appear over the first line of code if that line stretches the length of the box, though I think that's common to most implementations of this button.

Enabling the feature is done by adding `code_clipboard: true` to the frontmatter of the index.html.md file, similar to how search is enabled.

![Untitled](https://user-images.githubusercontent.com/1845314/84226398-a310b000-aaaf-11ea-9a48-7ace7f15600b.png)
