### PR TITLE
use different rouge theme for printing

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -31,8 +31,14 @@ under the License.
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title><%= current_page.data.title || "API Documentation" %></title>
 
-    <style>
+    <style media="screen">
       <%= Rouge::Themes::MonokaiSublimeSlate.render(:scope => '.highlight') %>
+    </style>
+    <style media="print">
+      * {
+        transition:none!important;
+      }
+      <%= Rouge::Themes::Base16::Solarized.render(:scope => '.highlight') %>
     </style>
     <%= stylesheet_link_tag :screen, media: :screen %>
     <%= stylesheet_link_tag :print, media: :print %>


### PR DESCRIPTION
Closes #1064 

This sets it so that the we use the simpler `Base16::Solarized` theme when going to print instead of `MonokaiSlate`, so that the code is legible on a white background to save on ink. See attached for example PDF resulting from this change.

[Test.pdf](https://github.com/slatedocs/slate/files/4756324/Test.pdf)

![Untitled](https://user-images.githubusercontent.com/1845314/84229887-b1af9500-aab8-11ea-8c5a-6ce1e14959b0.png)

------

For reference, the original PDF and sample image:
[Introduction.API.Reference.pdf](https://github.com/slatedocs/slate/files/4756329/Introduction.API.Reference.pdf)

![Untitled](https://user-images.githubusercontent.com/1845314/84229933-c9871900-aab8-11ea-9b54-ea1f970b6336.png)

