### PR TITLE
fix language bar truncating long list of langs

### DIFF
--- a/source/javascripts/all_nosearch.js
+++ b/source/javascripts/all_nosearch.js
@@ -3,6 +3,11 @@
 //= require ./app/_toc
 //= require ./app/_lang
 
+function adjustLanguageSelectorWidth() {
+  const elem = $('.dark-box > .lang-selector');
+  elem.width(elem.parent().width());
+}
+
 $(function() {
   loadToc($('#toc'), '.toc-link', '.toc-list-h2', 10);
   setupLanguages($('body').data('languages'));
@@ -10,6 +15,11 @@ $(function() {
     window.recacheHeights();
     window.refreshToc();
   });
+
+  $(window).resize(function() {
+    adjustLanguageSelectorWidth();
+  });
+  adjustLanguageSelectorWidth();
 });
 
 window.onpopstate = function() {

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -278,12 +278,13 @@ html, body {
 }
 
 .lang-selector {
+  display: flex;
   background-color: $lang-select-bg;
   width: 100%;
   font-weight: bold;
+  overflow-x: auto;
   a {
-    display: block;
-    float:left;
+    display: inline;
     color: $lang-select-text;
     text-decoration: none;
     padding: 0 10px;


### PR DESCRIPTION
Supersedes #1146 
Closes #961 

This sets things so that the language bar will now scroll if the list of languages exceeds the width of the space, while also keeping functionality the same as currently, which #1146 broke by moving from fixed to sticky.

The bug is a result that the fixed position of `.lang-selector` caused the `width: 100%` to be for the entire viewport, instead of just the available space. While `width: inherit` seemed promising a solution, it still caused things to be at a width of ~100px greater than the right column for some reason. I tried various CSS solutions to try and overcome it, but it never seemed to work properly, and so just ended up going with a JS solution which works perfectly and so gave up on the CSS solution.

![2020-06-20 20 00 56](https://user-images.githubusercontent.com/1845314/85213758-81df7780-b36b-11ea-9315-77c888d38530.gif)
