### PR TITLE
trim ending newline on copied code

### DIFF
--- a/source/javascripts/app/_copy.js
+++ b/source/javascripts/app/_copy.js
@@ -1,6 +1,6 @@
 function copyToClipboard(container) {
   const el = document.createElement('textarea');
-  el.value = container.textContent;
+  el.value = container.textContent.replace(/\n$/, '');
   document.body.appendChild(el);
   el.select();
   document.execCommand('copy');


### PR DESCRIPTION
Resolves #1295 

Currently, when a user hits the "copy to clipboard" button, the copied content has a trailing newline. This is probably fine for when you copy a code-block, but it is onerous in the case of one-line bash scripts as it causes them to "auto-execute" upon paste into the console.

This PR makes it so the final newline (which is added in the compilation from markdown -> html process) is trimmed before the copy to the clipboard. We only want to trim the final newline as that should make it so that if the user themselves inserts a bunch of trailing newlines (why, I don't know) themselves in their code box, we do not trim that.