### PR TITLE
Add dev deploy github action for previewing in-progress work on gh-pages

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -1,8 +1,8 @@
-name: Deploy
+name: Dev Deploy
 
 on:
   push:
-    branches: [ 'main' ]
+    branches: [ 'dev' ]
 
 jobs:
   deploy:
@@ -28,8 +28,9 @@ jobs:
     - run: bundle exec middleman build
 
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v3.7.0-8
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        destination_dir: dev
         publish_dir: ./build
         keep_files: true


### PR DESCRIPTION
This adds a new workflow "Dev Deploy", which on pushes to the `dev` branch, will build the static site, and deploy it to the `dev/` sub-directory on the `gh-pages` branch. This will allow someone to go to https://slatedocs.github.io/slate/ to view the latest released version, and go to https://slatedocs.github.io/slate/dev to view how it looks on the dev branch.

A downside is that to get this to work, the `keep_files` setting has been enabled, and so now deleted files will no longer be automatically removed from the `gh-pages` branch. However, given how little new files are introduced or old files removed, I do not view this as a major issue to I think the boon of being able to better view in-progress development.

Additionally, we can do a similar thing with v3 as well.