### PR TITLE
update actions/cache to v2 for gh workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,16 +21,22 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: gems-${{ runner.os }}-${{ matrix.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          gems-${{ runner.os }}-${{ matrix.ruby-version }}-
+          gems-${{ runner.os }}-
 
     # necessary to get ruby 2.3 to work nicely with bundler vendor/bundle cache
     # can remove once ruby 2.3 is no longer supported
     - run: gem update --system
 
     - run: bundle config set deployment 'true'
-    - run: bundle install
+    - name: bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
 
     - run: bundle exec middleman build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,13 +17,19 @@ jobs:
       with:
         ruby-version: ${{ env.ruby-version }}
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: gems-${{ runner.os }}-${{ env.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
+        key: gems-${{ runner.os }}-${{ matrix.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          gems-${{ runner.os }}-${{ matrix.ruby-version }}-
+          gems-${{ runner.os }}-
 
     - run: bundle config set deployment 'true'
-    - run: bundle install
+    - name: bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
 
     - run: bundle exec middleman build
 

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -17,13 +17,19 @@ jobs:
       with:
         ruby-version: ${{ env.ruby-version }}
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: gems-${{ runner.os }}-${{ env.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
+        key: gems-${{ runner.os }}-${{ matrix.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          gems-${{ runner.os }}-${{ matrix.ruby-version }}-
+          gems-${{ runner.os }}-
 
     - run: bundle config set deployment 'true'
-    - run: bundle install
+    - name: bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
 
     - run: bundle exec middleman build
 


### PR DESCRIPTION
In addition to updating the cache version, it brings the usage more inline with the recommended way (https://github.com/actions/cache/blob/main/examples.md#ruby---bundler) from their README. This should bring around a bit of speed improvements with using the cache.