### PR TITLE
add docker deploy step to github workflows

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -33,6 +33,14 @@ jobs:
 
     - run: bundle exec middleman build
 
+    - name: Push to Docker Hub
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_ACCESS_KEY }}
+        repository: slatedocs/slate
+        tag_with_ref: true
+
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3.7.0-8
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_KEY }}
+          repository: slatedocs/slate
+          tag_with_ref: true
+          tags: latest


### PR DESCRIPTION
This sets up the Github workflow to deploy to the [slatedocs/slate](https://hub.docker.com/r/slatedocs/slate) where:

* pushes to dev will deploy to the `dev` tag (overwriting any existing `dev` tag)
* published tags will publish to `latest` and `v#.#.#` tag (overwriting the `latest` tag)