### PR TITLE
Update command to fetch latest commit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -18,5 +18,5 @@ If applicable, add screenshots to help explain your problem.
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Last upstream Slate commit (run `git log --author="Robert Lord" | head -n 1`):**
+**Last upstream Slate commit (run `git log --author="\(Robert Lord\)\|\(Matthew Peveler\)\|\(Mike Ralphson\)" | head -n 1`):**
 Put the commit hash here


### PR DESCRIPTION
Currently, when making an issue, the git log command fetches the latest commit only by @lord and not @MikeRalphson or myself. This updates that line so that it should now return the latest commit by any of the three of us.