### PR TITLE
Add guards around localStorage in case user disables it

### DIFF
--- a/source/javascripts/app/_lang.js
+++ b/source/javascripts/app/_lang.js
@@ -129,11 +129,16 @@ under the License.
     history.pushState({}, '', '?' + generateNewQueryString(language) + '#' + hash);
 
     // save language as next default
-    localStorage.setItem("language", language);
+    if (localStorage) {
+      localStorage.setItem("language", language);
+    }
   }
 
   function setupLanguages(l) {
-    var defaultLanguage = localStorage.getItem("language");
+    var defaultLanguage = null;
+    if (localStorage) {
+      defaultLanguage = localStorage.getItem("language");
+    }
 
     languages = l;
 
@@ -142,7 +147,9 @@ under the License.
       // the language is in the URL, so use that language!
       activateLanguage(presetLanguage);
 
-      localStorage.setItem("language", presetLanguage);
+      if (localStorage) {
+        localStorage.setItem("language", presetLanguage);
+      }
     } else if ((defaultLanguage !== null) && (jQuery.inArray(defaultLanguage, languages) != -1)) {
       // the language was the last selected one saved in localstorage, so use that language!
       activateLanguage(defaultLanguage);


### PR DESCRIPTION
Fixes #1398 

This adds guards around the places where `localStorage` is called. This protects the site from crashing out if the user has blocked usage of `localStorage` for a site.