### PR TITLE
cut 2.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 *February 27, 2021*
 
-* Fix Slate language tabs not working if localStorage is diabled
+* Fix Slate language tabs not working if localStorage is disabled
 
 ## Version 2.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 2.9.1
+
+*February 27, 2021*
+
+* Fix Slate language tabs not working if localStorage is diabled
+
 ## Version 2.9.0
 
 *January 19, 2021*


### PR DESCRIPTION
Nice small bugfix release, do not have anything else cooking so might as well.

```
## Version 2.9.1

*February 27, 2021*

* Fix Slate language tabs not working if localStorage is disabled
```