### PR TITLE
Do not load lunr or jquery.highlight if search is disabled

### DIFF
--- a/source/_includes/slate.ejs
+++ b/source/_includes/slate.ejs
@@ -26,12 +26,12 @@ under the License.
     <link href="slate/css/print.css" media="print" rel="stylesheet">
     <link href="slate/css/screen.css" media="screen" rel="stylesheet">
     <script src="slate/js/lib/jquery.min.js"></script>
-    <script src="slate/js/lib/jquery.highlight.js"></script>
     <script src="slate/js/lib/energize.js"></script>
     <script src="slate/js/lib/imagesloaded.min.js"></script>
     <script src="slate/js/app/lang.js"></script>
     <script src="slate/js/app/toc.js"></script>
     <% if (search) { %>
+    <script src="slate/js/lib/jquery.highlight.js"></script>
     <script src="slate/js/lib/lunr.min.js"></script>
     <script src="slate/js/app/search.js"></script>
     <% } %>

--- a/source/_includes/slate.ejs
+++ b/source/_includes/slate.ejs
@@ -29,10 +29,10 @@ under the License.
     <script src="slate/js/lib/jquery.highlight.js"></script>
     <script src="slate/js/lib/energize.js"></script>
     <script src="slate/js/lib/imagesloaded.min.js"></script>
-    <script src="slate/js/lib/lunr.min.js"></script>
     <script src="slate/js/app/lang.js"></script>
     <script src="slate/js/app/toc.js"></script>
     <% if (search) { %>
+    <script src="slate/js/lib/lunr.min.js"></script>
     <script src="slate/js/app/search.js"></script>
     <% } %>
     <% if (typeof code_clipboard === 'boolean' && code_clipboard) { %>

--- a/test/golden/index.html
+++ b/test/golden/index.html
@@ -12,13 +12,13 @@
     <link href="slate/css/print.css" media="print" rel="stylesheet">
     <link href="slate/css/screen.css" media="screen" rel="stylesheet">
     <script src="slate/js/lib/jquery.min.js"></script>
-    <script src="slate/js/lib/jquery.highlight.js"></script>
     <script src="slate/js/lib/energize.js"></script>
     <script src="slate/js/lib/imagesloaded.min.js"></script>
-    <script src="slate/js/lib/lunr.min.js"></script>
     <script src="slate/js/app/lang.js"></script>
     <script src="slate/js/app/toc.js"></script>
     
+    <script src="slate/js/lib/jquery.highlight.js"></script>
+    <script src="slate/js/lib/lunr.min.js"></script>
     <script src="slate/js/app/search.js"></script>
     
     


### PR DESCRIPTION
This PR sets it so that `lunr.min.js` and `jquery.highlight.js` are only set to be loaded if search is enabled, as that is the only place that these are required.