### PR TITLE
Use Object.values for display name of object language definition

### DIFF
--- a/source/_includes/slate.ejs
+++ b/source/_includes/slate.ejs
@@ -138,7 +138,7 @@ under the License.
           <div class="lang-selector">
             <% for (var lang in language_tabs) { %>
               <% if (typeof language_tabs[lang] === 'object') { %>
-                <a href="#" data-language-name="<%= Object.keys(language_tabs[lang])[0] %>"><%= language_tabs[lang][Object.keys(language_tabs[lang])[0]]  %></a>
+                <a href="#" data-language-name="<%= Object.keys(language_tabs[lang])[0] %>"><%= language_tabs[lang][Object.values(language_tabs[lang])[0]]  %></a>
               <% } else { %>
                 <a href="#" data-language-name="<%= language_tabs[lang] %>"><%= language_tabs[lang] %></a>
               <% } %>


### PR DESCRIPTION
Fixes the v3 template for when language is defined as object to use the value of object for display name.

Relevant line from v2 is:
https://github.com/slatedocs/slate/blob/8488edf2d7eec2a28d035b36f3df130811a29bed/source/layouts/layout.erb#L118