### PR TITLE
Make Slate Compatible with Ruby 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '~> 2.5'
+ruby '> 2.5'
 source 'https://rubygems.org'
 
 # Middleman
@@ -10,3 +10,4 @@ gem 'rouge', '~> 3.21'
 gem 'redcarpet', '~> 3.5.0'
 gem 'nokogiri', '~> 1.11.0'
 gem 'sass'
+gem 'webrick'


### PR DESCRIPTION
I followed the Slate installation instructions to do a fresh install of Ruby, it installed Ruby 3.0.0. 

When running `bundle install`, I naturally got
```
Your Ruby version is 3.0.0, but your Gemfile specified ~> 2.5
```

I then changed `Gemfile` to support Ruby 3.0.0 and got the following error when running `bundle exec middleman server`:
```
bundler: failed to load command: middleman (/usr/local/lib/ruby/gems/3.0.0/bin/middleman)
/usr/local/lib/ruby/gems/3.0.0/gems/middleman-core-4.3.11/lib/middleman-core/util/paths.rb:7:in `require': cannot load such file -- webrick (LoadError)
```

I then added `gem 'webrick'` to the `Gemfile` and ran `bundle install` one last time based on https://github.com/middleman/middleman/issues/2422

After that, I got `bundle exec middleman server` to work on Ruby 3.0.0 without any issue.

It seems good to support Ruby 3 for Slate in general, and I don't really see a lot of downsides here?