### PR TITLE
Add git to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,11 @@ COPY Gemfile.lock .
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
+        git \
         nodejs \
     && gem install bundler \
     && bundle install \
-    && apt-get remove -y build-essential \
+    && apt-get remove -y build-essential git \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
#1424 fixed ruby 3.0, by updating the middleman dependency to depend directly on pulling from the latest commit on GitHub. This adds a requirement to have available git for bundler to work.