### PR TITLE
cut 2.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Version 2.10.0
+
+*April 13, 2021*
+
+* Add support for Ruby 3.0 (thanks @shaun-scale)
+* Add requirement for Git on installing dependencies
+* Bump nokogiri from 1.11.2 to 1.11.3
+* Bump middleman from 4.3.11 to [`d180ca3`](https://github.com/middleman/middleman/commit/d180ca337202873f2601310c74ba2b6b4cf063ec)
+
 ## Version 2.9.2
 
 *March 30, 2021*


### PR DESCRIPTION
```
## Version 2.10.0

*April 13, 2021*

* Add support for Ruby 3.0 (thanks @shaun-scale)
* Add requirement for Git on installing dependencies
* Bump nokogiri from 1.11.2 to 1.11.3
* Bump middleman from 4.3.11 to [`d180ca3`](https://github.com/middleman/middleman/commit/d180ca337202873f2601310c74ba2b6b4cf063ec)
```