### PR TITLE
Support specifying custom meta tags in YAML

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -29,6 +29,15 @@ under the License.
     <meta charset="utf-8">
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <% if current_page.data.key?('meta') %>
+      <% current_page.data.meta.each do |meta| %>
+        <meta
+          <% meta.each do |key, value| %>
+            <%= "#{key}=\"#{value}\"" %>
+          <% end %>
+        >
+      <% end %>
+    <% end %>
     <title><%= current_page.data.title || "API Documentation" %></title>
 
     <style media="screen">


### PR DESCRIPTION
This PR implements the suggestion from https://github.com/slatedocs/slate/discussions/1452#discussioncomment-803415, adding the ability to specify meta tags as YAML front-matter on your page. Implementation is the `meta` key in the front-matter points to a list of dictionaries where each dictionary key/value pair are plugged into the meta tag.


For example, if I wanted to specify a description and keywords, I can do:

```yaml
meta:
  - name: description
    content: Slate is the best API generator
  - name: keywords
    content: API, Slate
```

and this would generate the meta tags:
```html
        <meta
            name="description"
            content="Slate is the best API generator"
        >
        <meta
            name="keywords"
            content="API, Slate"
        >
```
in the resulting source.