### PR TITLE
Fix incorrect ruby-version parameter in deploy GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,9 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: gems-${{ runner.os }}-${{ matrix.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
+        key: gems-${{ runner.os }}-${{ env.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          gems-${{ runner.os }}-${{ matrix.ruby-version }}-
+          gems-${{ runner.os }}-${{ env.ruby-version }}-
           gems-${{ runner.os }}-
 
     - run: bundle config set deployment 'true'

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -20,9 +20,9 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: gems-${{ runner.os }}-${{ matrix.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
+        key: gems-${{ runner.os }}-${{ env.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          gems-${{ runner.os }}-${{ matrix.ruby-version }}-
+          gems-${{ runner.os }}-${{ env.ruby-version }}-
           gems-${{ runner.os }}-
 
     - run: bundle config set deployment 'true'


### PR DESCRIPTION
In the deploy action we aren't using a matrix and so we should reference the env directly. And that's because instead of something like this:

https://github.com/slatedocs/slate/blob/50c927185f26affbdb47e6fa08a92f13900f4ab5/.github/workflows/build.yml#L13-L15

We have these:

https://github.com/slatedocs/slate/blob/50c927185f26affbdb47e6fa08a92f13900f4ab5/.github/workflows/deploy.yml#L10-L11

https://github.com/slatedocs/slate/blob/50c927185f26affbdb47e6fa08a92f13900f4ab5/.github/workflows/dev_deploy.yml#L10-L11