### PR TITLE
Add CoinAPI to README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Companies Using Slate
 * [Clearbit](https://clearbit.com/docs)
 * [Coinbase](https://developers.coinbase.com/api)
 * [Parrot Drones](http://developer.parrot.com/docs/bebop/)
+* [CoinAPI](https://docs.coinapi.io/)
 
 You can view more in [the list on the wiki](https://github.com/slatedocs/slate/wiki/Slate-in-the-Wild).
 


### PR DESCRIPTION
Adding CoinAPI to the README. We have possibly the most beautiful customization of the Slate and certainly deserving to be in the README ;-) If not let me know how we can improve that further.