### PR TITLE
Bump ffi from 1.15.0 to 1.15.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     execjs (2.7.0)
     fast_blank (1.0.0)
     fastimage (2.2.4)
-    ffi (1.15.0)
+    ffi (1.15.4)
     haml (5.2.1)
       temple (>= 0.8.0)
       tilt
@@ -142,4 +142,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.20
+   2.2.22


### PR DESCRIPTION
[Version 1.15.1](https://github.com/ffi/ffi/blob/master/CHANGELOG.md#1151--2021-05-22) of ffi includes an important fix for usage of it on Apple ARM CPUs (M1).

I was running into an issue with the `Listen` gem not able to connect to the host's listen events when run within a Docker container, and updating Slate to use the latest version of ffi locally appears to fix that.