### PR TITLE
Add support to build multi-arch docker images

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -25,9 +25,6 @@ jobs:
           slatedocs/slate
         tags: |
           type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=sha
 
     - name: Set up Docker Buildx
       id: buildx
@@ -49,3 +46,40 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+
+  deploy_gh:
+    permissions:
+      contents: write
+
+    runs-on: ubuntu-latest
+    env:
+      ruby-version: 2.5
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ env.ruby-version }}
+
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: gems-${{ runner.os }}-${{ env.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          gems-${{ runner.os }}-${{ env.ruby-version }}-
+          gems-${{ runner.os }}-
+    - run: bundle config set deployment 'true'
+    - name: bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+    - run: bundle exec middleman build
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3.7.0-8
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        destination_dir: dev
+        publish_dir: ./build
+        keep_files: true

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -2,7 +2,7 @@ name: Dev Deploy
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ 'dev' ]
 
 jobs:
   push_to_registry:

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -13,13 +13,25 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@master
+      uses: docker/setup-qemu-action@v1
       with:
         platforms: all
 
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          slatedocs/slate
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=sha
+
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@master
+      uses: docker/setup-buildx-action@v1
 
     - name: Login to DockerHub
       uses: docker/login-action@v1
@@ -28,9 +40,12 @@ jobs:
         password: ${{ secrets.DOCKER_ACCESS_KEY }}
 
     - name: Push to Docker Hub
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
         builder: ${{ steps.buildx.outputs.name }}
-        repository: slatedocs/slate
+        context: .
+        file: ./Dockerfile
         platforms: linux/amd64,linux/arm64,linux/ppc64le
-        tag_with_ref: true
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -2,7 +2,7 @@ name: Dev Deploy
 
 on:
   push:
-    branches: [ 'dev' ]
+    branches: [ '*' ]
 
 jobs:
   push_to_registry:
@@ -12,49 +12,25 @@ jobs:
     - name: Check out the repo
       uses: actions/checkout@v2
 
-    - name: Push to Docker Hub
-      uses: docker/build-push-action@v1
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@master
+      with:
+        platforms: all
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@master
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_ACCESS_KEY }}
+
+    - name: Push to Docker Hub
+      uses: docker/build-push-action@v1
+      with:
+        builder: ${{ steps.buildx.outputs.name }}
         repository: slatedocs/slate
+        platforms: linux/amd64,linux/arm64,linux/ppc64le
         tag_with_ref: true
-  
-  deploy_gh:
-    permissions:
-      contents: write
-
-    runs-on: ubuntu-latest
-    env:
-      ruby-version: 2.5
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ env.ruby-version }}
-
-    - uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: gems-${{ runner.os }}-${{ env.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          gems-${{ runner.os }}-${{ env.ruby-version }}-
-          gems-${{ runner.os }}-
-
-    - run: bundle config set deployment 'true'
-    - name: bundle install
-      run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
-
-    - run: bundle exec middleman build
-
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3.7.0-8
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        destination_dir: dev
-        publish_dir: ./build
-        keep_files: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,11 +12,36 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: slatedocs/slate
+          tags: |
+            type=ref,event=tag
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_KEY }}
-          repository: slatedocs/slate
-          tag_with_ref: true
-          tags: latest
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Closes #1576 

This modifies the GH workflows so that we will generate docker images for the `linux/amd64`, `linux/arm64`, and `linux/ppc64le` platforms, where we were before just providing `linux/amd64`.

In the future, if someone requests, we could expand this list with `linux/386`, `linux/arm/v5`, `linux/arm/v7`, `linux/mips64le`, and `linux/s390x` as per what's supported by the `ruby:2.6-slim` base images. I've chosen not to include those here just to lower the amount of targets and potential support maintenance of all these other images until someone's actually needs them.