### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.5, 2.6, 2.7, '3.0', 3.1]
+        ruby-version: [2.6, 2.7, '3.0', 3.1]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      ruby-version: 2.5
+      ruby-version: 2.6
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -53,7 +53,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      ruby-version: 2.5
+      ruby-version: 2.6
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '>= 2.5'
+ruby '>= 2.6'
 source 'https://rubygems.org'
 
 # Middleman

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "ubuntu/focal64"
   config.vm.network :forwarded_port, guest: 4567, host: 4567
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "2048"
@@ -28,7 +28,7 @@ Vagrant.configure(2) do |config|
       echo "=============================================="
       echo "Installing app dependencies"
       cd /vagrant
-      sudo gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)" 
+      sudo gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
       bundle config build.nokogiri --use-system-libraries
       bundle install
     SHELL


### PR DESCRIPTION
This PR drops support for Ruby 2.5, which reached end-of-life almost a year ago on `2021-03-31`. The main pushing factor here is that Nokogiri 1.13.2 contained fixes for two reported CVEs on things it will include if you don't use system libraries, while Nokogiri 1.13.0 dropped support for Ruby 2.5, so we cannot upgrade the dependency so long as we still support Ruby 2.5. The biggest impact would be on people using slate on Ubuntu 18.04 as it uses Ruby 2.5, but I think there are adequate workarounds for those on that server, via installing a newer ruby version with a ppa or using docker.