### PR TITLE
Remove VOLUME declaration from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM ruby:2.6-slim
 
 WORKDIR /srv/slate
 
-VOLUME /srv/slate/build
-VOLUME /srv/slate/source
-
 EXPOSE 4567
 
 COPY Gemfile .


### PR DESCRIPTION
These `VOLUME` lines are more trouble than they're worth. When building in CI, the build artifacts will not persist in the final image.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->