### PR TITLE
Expand git.io link to full url in template

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1,7 +1,7 @@
 ---
 title: API Reference
 
-language_tabs: # must be one of https://git.io/vQNgJ
+language_tabs: # must be one of https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers
   - shell
   - ruby
   - python

--- a/source/stylesheets/_normalize.scss
+++ b/source/stylesheets/_normalize.scss
@@ -1,4 +1,4 @@
-/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
+/*! normalize.css v3.0.2 | MIT License | github.com/necolas/normalize.css */
 
 /**
  * 1. Set default font family to sans-serif.


### PR DESCRIPTION
[GitHub is depreciating git.io](https://github.blog/changelog/2022-04-25-git-io-deprecation/). While they have an update stating that existing git.io URLs will be archived, they still recommend using a different link shortener, or rather, use the canonical URL for linked resources when possible.

This also updates `_normalize.scss` to remove the git.io URL, which the normalize repo fixed back in 2015: https://github.com/necolas/normalize.css/issues/411