### PR TITLE
Disable file watcher in run_build() for the sake of qemu on arm64

### DIFF
--- a/slate.sh
+++ b/slate.sh
@@ -35,7 +35,7 @@ run_serve() {
 }
 
 run_build() {
-  bundle exec middleman build --clean
+  bundle exec middleman build --clean --watcher-disable
 }
 
 parse_args() {


### PR DESCRIPTION
While `slatedocs/slate` native `linux/arm64` Docker image is available, running `linux/amd64` image on ARM64 (Apple silicon) triggers the infamous `Failed to initialize inotify (Errno::ENOSYS)` error. It is particularly annoying when one attempts to use Slate's `linux/amd64` image on ARM (e.g. as part of multi-arch build).

There appears to be no reason not to disable the watcher in `run_build()` function in `slate.sh`, since it's used as one time call.