### PR TITLE
Dependency error when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-slim
+FROM ruby:2.7.6-slim
 
 WORKDIR /srv/slate
 


### PR DESCRIPTION
When attempting to build the docker image, it gives the following error:
``` Fed  ~/repos/slate  on main !2 ?1  sudo docker run --rm --name slate -p 4567:4567 -v $(pwd)/source:/srv/slate/source slatedocs/slate serve                                                  ✔  took 1m 55s  at 09:10:01 AM  98% █ 
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
bundler: failed to load command: middleman (/usr/local/bundle/bin/middleman)
<internal:dir>:98:in `open': Permission denied @ dir_initialize - /srv/slate/source (Errno::EACCES)
	from /usr/local/lib/ruby/3.1.0/pathname.rb:446:in `foreach'
	from /usr/local/lib/ruby/3.1.0/pathname.rb:446:in `children'
	from /usr/local/bundle/gems/middleman-core-4.4.2/lib/middleman-core/util/files.rb:23:in `all_files_under'
	from /usr/local/bundle/gems/middleman-core-4.4.2/lib/middleman-core/sources/source_watcher.rb:209:in `poll_once!'
	from /usr/local/bundle/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
	from /usr/local/bundle/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
	from /usr/local/bundle/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
	from /usr/local/bundle/gems/middleman-core-4.4.2/lib/middleman-core/sources.rb:241:in `block in poll_once!'
	from /usr/local/bundle/gems/middleman-core-4.4.2/lib/middleman-core/sources.rb:241:in `each'
	from /usr/local/bundle/gems/middleman-core-4.4.2/lib/middleman-core/sources.rb:241:in `reduce'
	from /usr/local/bundle/gems/middleman-core-4.4.2/lib/middleman-core/sources.rb:241:in `poll_once!'
	from /usr/local/bundle/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
	from /usr/local/bundle/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
	from /usr/local/bundle/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
	from /usr/local/bundle/gems/middleman-core-4.4.2/lib/middleman-core/core_extensions/file_watcher.rb:47:in `before_configuration'
	from /usr/local/bundle/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
	from /usr/local/bundle/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
	from /usr/local/bundle/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
	from /usr/local/bundle/gems/middleman-core-4.4.2/lib/middleman-core/callback_manager.rb:57:in `instance_exec'
	from /usr/local/bundle/gems/middleman-core-4.4.2/lib/middleman-core/callback_manager.rb:57:in `block in execute'
	from /usr/local/bundle/gems/hamster-3.0.0/lib/hamster/vector.rb:1316:in `each'
	from /usr/local/bundle/gems/hamster-3.0.0/lib/hamster/vector.rb:1316:in `traverse_depth_first'
	from /usr/local/bundle/gems/hamster-3.0.0/lib/hamster/vector.rb:431:in `each'
	from /usr/local/bundle/gems/middleman-core-4.4.2/lib/middleman-core/callback_manager.rb:57:in `execute'
	from /usr/local/bundle/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
	from /usr/local/bundle/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
	from /usr/local/bundle/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
	from /usr/local/bundle/gems/middleman-core-4.4.2/lib/middleman-core/callback_manager.rb:28:in `block in install_methods!'
	from /usr/local/bundle/gems/middleman-core-4.4.2/lib/middleman-core/application.rb:283:in `initialize'
	from /usr/local/bundle/gems/middleman-cli-4.4.2/bin/middleman:49:in `new'
	from /usr/local/bundle/gems/middleman-cli-4.4.2/bin/middleman:49:in `<top (required)>'
	from /usr/local/bundle/bin/middleman:25:in `load'
	from /usr/local/bundle/bin/middleman:25:in `<top (required)>'
	from /usr/local/bundle/gems/bundler-2.2.22/lib/bundler/cli/exec.rb:63:in `load'
	from /usr/local/bundle/gems/bundler-2.2.22/lib/bundler/cli/exec.rb:63:in `kernel_load'
	from /usr/local/bundle/gems/bundler-2.2.22/lib/bundler/cli/exec.rb:28:in `run'
	from /usr/local/bundle/gems/bundler-2.2.22/lib/bundler/cli.rb:474:in `exec'
	from /usr/local/bundle/gems/bundler-2.2.22/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /usr/local/bundle/gems/bundler-2.2.22/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /usr/local/bundle/gems/bundler-2.2.22/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /usr/local/bundle/gems/bundler-2.2.22/lib/bundler/cli.rb:30:in `dispatch'
	from /usr/local/bundle/gems/bundler-2.2.22/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /usr/local/bundle/gems/bundler-2.2.22/lib/bundler/cli.rb:24:in `start'
	from /usr/local/bundle/gems/bundler-2.2.22/exe/bundle:49:in `block in <top (required)>'
	from /usr/local/bundle/gems/bundler-2.2.22/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
	from /usr/local/bundle/gems/bundler-2.2.22/exe/bundle:37:in `<top (required)>'
	from /usr/local/bundle/bin/bundle:25:in `load'
	from /usr/local/bundle/bin/bundle:25:in `<main>'
```
Upgraded base image which works fine.