### PR TITLE
ci: pinning build.yml rubygems-update version in GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
     # necessary to get ruby 2.3 to work nicely with bundler vendor/bundle cache
     # can remove once ruby 2.3 is no longer supported
-    - run: gem update --system
+    - run: gem update --system 3.4.22
 
     - run: bundle config set deployment 'true'
     - name: bundle install


### PR DESCRIPTION
Hi 👋 

I'm using Slate for a documentation project and it's awesome! 🚀 

Recently, I've started noticing GitHub Action failures for `Build` job with the following error:

```
Run gem update --system
ERROR:  Error installing rubygems-update:
	There are no versions of rubygems-update (= 3.5.4) compatible with your Ruby & RubyGems
	rubygems-update requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
```

This happens when ruby-version from matrix in `build.yml` is 2.6 or 2.7 etc.

At the time of writing, the latest rubygems-update compatible with ruby 2.6 is: `3.4.22` ([see here](https://rubygems.org/gems/rubygems-update/versions/3.4.22))

Any rubygems-update from 3.5.x (at the time of writing, latest is 3.5.4) requires ruby >= 3.0.0
making this `build.yml` to fail.

Pinning rubygems-update to `3.4.22` for the GHA ci scope solved our Build GHA runs; proposing the same here if that helps other Slate users, or looking forward to hearing improving feedback for alternative (or more proper?) solution.