### PR TITLE
Remove updating gem from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,6 @@ jobs:
           gems-${{ runner.os }}-${{ matrix.ruby-version }}-
           gems-${{ runner.os }}-
 
-    # necessary to get ruby 2.3 to work nicely with bundler vendor/bundle cache
-    # can remove once ruby 2.3 is no longer supported
-    - run: gem update --system
-
     - run: bundle config set deployment 'true'
     - name: bundle install
       run: |


### PR DESCRIPTION
Per the comment, we were only doing `gem update --system` to avoid an error that was present in Ruby 2.3. Given that support for that was dropped in [2.9.0](https://github.com/slatedocs/slate/releases/tag/v2.9.0) 3 years ago, probably fine to get rid of this shim as well.